### PR TITLE
Fix code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -29,4 +29,4 @@ def get_user():
 
 if __name__ == '__main__':
     debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
-    app.run(debug=True)
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/fijupepa/test-autofix/security/code-scanning/2](https://github.com/fijupepa/test-autofix/security/code-scanning/2)

To fix the problem, we need to ensure that the Flask application only runs in debug mode when explicitly intended, typically during development. We can achieve this by using the `debug_mode` variable, which is already being set based on the `FLASK_DEBUG` environment variable. We should pass this variable to the `app.run()` method instead of hardcoding `debug=True`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
