### PR TITLE
Fix code scanning alert no. 5: Uncontrolled command line

### DIFF
--- a/erros_checkmarx.py
+++ b/erros_checkmarx.py
@@ -9,12 +9,21 @@ app = Flask(__name__)
 DB_PASSWORD = "supersecretpassword"
 
 # Problema 2: Comando de sistema vulnerável à injeção
+ALLOWED_COMMANDS = {
+    "list": "ls",
+    "status": "stat"
+}
+
 @app.route("/run", methods=["POST"])
 def run_command():
     user_input = request.form.get("command")
-    # Executa o comando recebido do usuário sem validação
-    result = subprocess.check_output(user_input, shell=True)
-    return result
+    # Valida o comando recebido do usuário
+    if user_input in ALLOWED_COMMANDS:
+        command = ALLOWED_COMMANDS[user_input]
+        result = subprocess.check_output(command, shell=True)
+        return result
+    else:
+        return "Comando não permitido", 400
 
 # Problema 3: Validação inadequada de entrada do usuário
 @app.route("/login", methods=["POST"])


### PR DESCRIPTION
Fixes [https://github.com/fijupepa/test-autofix/security/code-scanning/5](https://github.com/fijupepa/test-autofix/security/code-scanning/5)

To fix the problem, we should avoid directly using user input in system commands. Instead, we should use a predefined allowlist of acceptable commands and validate the user input against this allowlist. This ensures that only known, safe commands are executed.

1. Define a dictionary of allowed commands.
2. Check if the user input matches any of the allowed commands.
3. Execute the command only if it is in the allowlist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
