### PR TITLE
Fix code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/erros_checkmarx.py
+++ b/erros_checkmarx.py
@@ -31,8 +31,14 @@ def login():
 @app.route("/read", methods=["POST"])
 def read_file():
     filename = request.form.get("filename")
-    # Permite acesso a arquivos arbitrários
-    with open(filename, "r") as file:
+    # Define a safe root directory
+    safe_root = "/safe/directory"
+    # Normalize the path and check if it is within the safe root directory
+    fullpath = os.path.normpath(os.path.join(safe_root, filename))
+    if not fullpath.startswith(safe_root):
+        return "Access denied: Invalid file path", 400
+    # Open the file if the path is valid
+    with open(fullpath, "r") as file:
         data = file.read()
     return data
 


### PR DESCRIPTION
Fixes [https://github.com/fijupepa/test-autofix/security/code-scanning/6](https://github.com/fijupepa/test-autofix/security/code-scanning/6)

To fix the problem, we need to validate the `filename` obtained from the user input before using it in the `open` function. We can achieve this by normalizing the path and ensuring it is within a safe root directory. This will prevent directory traversal attacks and ensure that only files within the allowed directory can be accessed.

1. Define a safe root directory where files can be accessed.
2. Normalize the user-provided path using `os.path.normpath`.
3. Check if the normalized path starts with the safe root directory.
4. If the path is valid, proceed to open the file; otherwise, raise an exception or return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
