### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/maiserror2025.py
+++ b/maiserror2025.py
@@ -23,7 +23,7 @@ def load_data(data):
 
 # 5. Exposição de informações sensíveis via logs
 def login(user, password):
-    print(f"Usuário: {user}, Senha: {password}")  # CWE-532
+    print(f"Usuário: {user}, Senha: [REDACTED]")  # CWE-532
 
 # 6. Download inseguro de conteúdo externo
 def fetch_remote_file(url):


### PR DESCRIPTION
Potential fix for [https://github.com/fijupepa/test-autofix/security/code-scanning/8](https://github.com/fijupepa/test-autofix/security/code-scanning/8)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead of logging the actual password, we can log a placeholder or simply avoid logging the password altogether. This change should be made in the `login` function where the sensitive data is being logged.

The best way to fix this without changing existing functionality is to modify the print statement to exclude the password. We can log the username and a placeholder for the password instead. This change will be made in the `login` function on line 26 of the `maiserror2025.py` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
